### PR TITLE
Adds native interface detection for isTablet and isPhone

### DIFF
--- a/DisplayDeviceUtil.m
+++ b/DisplayDeviceUtil.m
@@ -40,4 +40,14 @@ RCT_EXPORT_MODULE();
   [_bridge.eventDispatcher sendDeviceEventWithName:@"orientationDidChange" body:dimensions];
 }
 
+- (NSDictionary *)constantsToExport {
+  BOOL isPhone = [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone;
+  BOOL isTablet = [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad;
+  
+  return @{
+    @"isPhone" : @(isPhone),
+    @"isTablet" : @(isTablet)
+  };
+}
+
 @end

--- a/display.js
+++ b/display.js
@@ -1,3 +1,6 @@
+var { NativeModules } = require('react-native');
+
+var DeviceUtil = NativeModules.DisplayDeviceUtil;
 var Dimensions = require('Dimensions');
 var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
 
@@ -7,7 +10,7 @@ class Display {
     this.width = newWidth;
     this.height = newHeight;
   }
-  
+
   constructor() {
     this.width = Dimensions.get("window").width;
     this.height = Dimensions.get("window").height;
@@ -40,30 +43,18 @@ class Display {
   }
 
   isTablet() {
-    if ((this.width > 760 || this.height > 899) && this.isPortrait()) {
-      return true;
-    } else if ((this.width > 899 || this.height > 760) && this.isLandscape()) {
-      return true;
-    } else {
-      return false;
-    }
+    return DeviceUtil.isTablet;
   }
 
   isPhone() {
-    if ((this.width <= 760 || this.height <= 899) && this.isPortrait()) {
-      return true;
-    } else if ((this.width <= 899 || this.height <= 760) && this.isLandscape()) {
-      return true;
-    } else {
-      return false;
-    }
+    return DeviceUtil.isPhone;
   }
 
   onOrientationDidChange(handler) {
     var main = this;
-  	RCTDeviceEventEmitter.addListener(
-  		'orientationDidChange',
-  		function(newDimensions) {
+    RCTDeviceEventEmitter.addListener(
+      'orientationDidChange',
+      function(newDimensions) {
         main.updateProps(newDimensions.width, newDimensions.height);
         handler();
       }


### PR DESCRIPTION
- Uses the native `userInterfaceIdiom` of `UIDevice` to simplify device detection and not rely on dimensions that could change in the future.

Reference: https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIDevice_Class/index.html#//apple_ref/occ/instp/UIDevice/userInterfaceIdiom
