### PR TITLE
fix width/height reversal, some flakiness

### DIFF
--- a/DisplayDeviceUtil.h
+++ b/DisplayDeviceUtil.h
@@ -2,4 +2,6 @@
 
 @interface DisplayDeviceUtil : NSObject <RCTBridgeModule>
 
+- (NSDictionary *)getDimensions;
+
 @end

--- a/DisplayDeviceUtil.m
+++ b/DisplayDeviceUtil.m
@@ -16,7 +16,7 @@ RCT_EXPORT_MODULE();
                                                  name:UIDeviceOrientationDidChangeNotification
                                                object:nil];
   }
-  
+
   return self;
 }
 
@@ -24,28 +24,41 @@ RCT_EXPORT_MODULE();
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (void)displayOrientationDidChange:(NSNotification*)note {
-  CGSize frameSize = [UIScreen mainScreen].applicationFrame.size;
-  
+- (NSDictionary *)getDimensions {
+  CGSize frameSize = [UIScreen mainScreen].bounds.size;
+
   /* For Non-Orientation Dependant Versions */
   if ((NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1)
       && UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)) {
     frameSize = CGSizeMake(frameSize.height, frameSize.width);
   }
-  
-  NSDictionary *dimensions = @{ @"width": @(frameSize.height), @"height": @(frameSize.width) };
-  NSLog(@"%@", dimensions);
+
+  NSDictionary *dimensions = @{ @"width": @(frameSize.width), @"height": @(frameSize.height) };
+  return dimensions;
+}
+
+- (void)displayOrientationDidChange:(NSNotification*)note {
+  NSDictionary *dimensions = [self getDimensions];
   [_bridge.eventDispatcher sendDeviceEventWithName:@"orientationDidChange" body:dimensions];
 }
 
 - (NSDictionary *)constantsToExport {
   BOOL isPhone = [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone;
   BOOL isTablet = [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad;
-  
+  NSDictionary *dimensions = [self getDimensions];
+
   return @{
-    @"isPhone" : @(isPhone),
-    @"isTablet" : @(isTablet)
-  };
+           @"isPhone" : @(isPhone),
+           @"isTablet" : @(isTablet),
+           @"initialDimensions": dimensions
+           };
+}
+
+RCT_EXPORT_METHOD(getFrameSize:(RCTResponseSenderBlock)callback)
+{
+  CGSize frameSize = [UIScreen mainScreen].applicationFrame.size;
+  NSDictionary *dimensions = @{ @"width": @(frameSize.width), @"height": @(frameSize.height) };
+  callback(@[dimensions]);
 }
 
 @end

--- a/display.js
+++ b/display.js
@@ -1,7 +1,6 @@
 var { NativeModules } = require('react-native');
 
 var DeviceUtil = NativeModules.DisplayDeviceUtil;
-var Dimensions = require('Dimensions');
 var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
 
 class Display {
@@ -12,8 +11,8 @@ class Display {
   }
 
   constructor() {
-    this.width = Dimensions.get("window").width;
-    this.height = Dimensions.get("window").height;
+    this.width = DeviceUtil.initialDimensions.width;
+    this.height = DeviceUtil.initialDimensions.height;
   }
 
   percentage(type, value) {
@@ -54,13 +53,27 @@ class Display {
     var main = this;
     return RCTDeviceEventEmitter.addListener(
       'orientationDidChange',
-      function(newDimensions) {
-        main.updateProps(newDimensions.width, newDimensions.height);
-        handler();
+      (/*newDimensions*/) => {
+        // Not sure why, but sometimes dimensions is not updated. But asking
+        // again, it always seems to be correct.
+        this.getFrameSize((newDimensions) => {
+          main.updateProps(newDimensions.width, newDimensions.height);
+          handler();
+        });
       }
     );
   }
 
+  dimensions() {
+    return {
+      width: this.width,
+      height: this.height
+    };
+  }
+
+  getFrameSize(cb) {
+    DeviceUtil.getFrameSize(cb);
+  }
 }
 
 module.exports = new Display();

--- a/display.js
+++ b/display.js
@@ -53,10 +53,10 @@ class Display {
     var main = this;
     return RCTDeviceEventEmitter.addListener(
       'orientationDidChange',
-      (/*newDimensions*/) => {
+      function (/*newDimensions*/) {
         // Not sure why, but sometimes dimensions is not updated. But asking
         // again, it always seems to be correct.
-        this.getFrameSize((newDimensions) => {
+        main.getFrameSize(function (newDimensions) {
           main.updateProps(newDimensions.width, newDimensions.height);
           handler();
         });


### PR DESCRIPTION
`width` and `height` were being reversed in the orientation change event data, so fixed that.

I also noticed some general flakiness where sometimes the event would give outdated width and height. I added a `getDimensions` function and call that when the orientation changes, and this seemed to be more robust. No idea why, but it's working much better for me, so thought I'd share!
