### PR TITLE
Rename RCTDeviceEventEmitter to DeviceEventEmitter

### DIFF
--- a/display.js
+++ b/display.js
@@ -1,6 +1,6 @@
 var {
   Dimensions,
-  RCTDeviceEventEmitter,
+  DeviceEventEmitter,
   NativeModules
 } = require('react-native');
 
@@ -56,7 +56,7 @@ class Display {
 
   onOrientationDidChange(handler) {
     var main = this;
-    return RCTDeviceEventEmitter.addListener(
+    return DeviceEventEmitter.addListener(
       'orientationDidChange',
       function(newDimensions) {
         main.updateProps(newDimensions.width, newDimensions.height);

--- a/display.js
+++ b/display.js
@@ -1,6 +1,6 @@
 var {
-  Dimensions,
   DeviceEventEmitter,
+  Dimensions,
   NativeModules
 } = require('react-native');
 


### PR DESCRIPTION
React Native exports RCTDeviceEventEmitter as DeviceEventEmitter.

See: https://github.com/facebook/react-native/blob/a95405f4194480d22005df0ac1c32e44753d17be/Libraries/react-native/react-native.js#L108
